### PR TITLE
fix: move away from post-hoc string processing for schema generation

### DIFF
--- a/src/checkedframe/_schema_generation.py
+++ b/src/checkedframe/_schema_generation.py
@@ -147,10 +147,10 @@ def generate_schema_repr(
             kwargs_to_show.append(f"{k}={v}")
 
         display_kwargs = ", ".join(kwargs_to_show)
-        display_dtype = str(cf_dtype).replace("(", f"({import_alias}")
+        display_dtype = cf_dtype._to_repr(import_alias)
 
         columns.append(
-            f"    {sanitized_col} = {import_alias}{display_dtype}({display_kwargs})".replace(
+            f"    {sanitized_col} = {display_dtype}({display_kwargs})".replace(
                 ")(", ", " if len(kwargs_to_show) > 0 else ""
             )
         )

--- a/tests/test_schema_parsing.py
+++ b/tests/test_schema_parsing.py
@@ -1,4 +1,4 @@
-import tempfile
+import datetime
 
 import polars as pl
 import pytest
@@ -103,17 +103,27 @@ def test_schema_generation():
         "class AASchema(cf.Schema):\n"
         '    column_0 = cf.Float64(name="reason code", nullable=True, allow_nan=True)\n'
         "    y = cf.List(cf.Int64, nullable=True)\n"
-        "    z = cf.List(cf.List(cf.Int64), nullable=True)"
+        "    z = cf.List(cf.List(cf.Int64), nullable=True)\n"
+        '    datetime = cf.Datetime(time_unit="us", time_zone=None)\n'
+        '    struct = cf.Struct({"a": cf.Int64, "b": cf.Struct({"d": cf.List(cf.Int64)})}, nullable=True)'
+    )
+
+    df = pl.DataFrame(
+        {
+            "reason code": [1.0, float("nan"), None],
+            "y": [[1], [2], None],
+            "z": [[[1]], None, [[3]]],
+            "datetime": datetime.datetime(2016, 1, 22),
+            "struct": [
+                {"a": 1, "b": {"d": [1, 2, 3]}},
+                {"a": 2, "b": {"d": [1, 2, 3]}},
+                None,
+            ],
+        }
     )
 
     schema_repr = cf.generate_schema_repr(
-        pl.DataFrame(
-            {
-                "reason code": [1.0, float("nan"), None],
-                "y": [[1], [2], None],
-                "z": [[[1]], None, [[3]]],
-            }
-        ),
+        df,
         class_name="AASchema",
     )
 
@@ -127,7 +137,9 @@ def test_schema_generation_lazy():
         "class AASchema(cf.Schema):\n"
         '    column_0 = cf.Float64(name="reason code")\n'
         "    y = cf.List(cf.Int64)\n"
-        "    z = cf.List(cf.List(cf.Int64))"
+        "    z = cf.List(cf.List(cf.Int64))\n"
+        '    datetime = cf.Datetime(time_unit="us", time_zone=None)\n'
+        '    struct = cf.Struct({"a": cf.Int64, "b": cf.Struct({"d": cf.List(cf.Int64)})})'
     )
 
     df = pl.DataFrame(
@@ -135,6 +147,12 @@ def test_schema_generation_lazy():
             "reason code": [1.0, float("nan"), None],
             "y": [[1], [2], None],
             "z": [[[1]], None, [[3]]],
+            "datetime": datetime.datetime(2016, 1, 22),
+            "struct": [
+                {"a": 1, "b": {"d": [1, 2, 3]}},
+                {"a": 2, "b": {"d": [1, 2, 3]}},
+                None,
+            ],
         }
     )
 


### PR DESCRIPTION
String schema generation used to do post-hoc string processing. Now, each class understands its own repr. This fixes a lot of bugs related to recursive structures (like struct of structs) and various issues with displaying arguments as well.